### PR TITLE
#7 Add field "endAt" to Course entity, add method for getting all course

### DIFF
--- a/src/main/java/org/otus/platform/courseservice/controller/VebinarController.java
+++ b/src/main/java/org/otus/platform/courseservice/controller/VebinarController.java
@@ -24,31 +24,31 @@ public class VebinarController {
     private final VebinarService vebinarService;
 
     @GetMapping("/list/{id}")
-    ResponseEntity<VebinarListDto> getCourseScheduleListByCourse(@NotNull @PathVariable UUID id) {
+    ResponseEntity<VebinarListDto> getVebinarListByCourse(@NotNull @PathVariable UUID id) {
         var response = vebinarService.getVebinarListByCourse(id);
         return ResponseEntity.ok(response);
     }
 
     @GetMapping("/{id}")
-    ResponseEntity<VebinarDto> getCourseScheduleById(@NotNull @PathVariable UUID id) {
+    ResponseEntity<VebinarDto> getCVebinarById(@NotNull @PathVariable UUID id) {
         var response = vebinarService.getVebinarById(id);
         return ResponseEntity.ok(response);
     }
 
     @PostMapping("/create")
-    ResponseEntity<VebinarDto> createCourseSchedule(@Valid @RequestBody VebinarCreateRequest request) {
+    ResponseEntity<VebinarDto> createVebinar(@Valid @RequestBody VebinarCreateRequest request) {
         var response = vebinarService.createVebinar(request);
         return ResponseEntity.ok(response);
     }
 
     @PutMapping("/update")
-    ResponseEntity<VebinarDto> updateCourseSchedule(@Valid @RequestBody VebinarUpdateRequest request) {
+    ResponseEntity<VebinarDto> updateVebinar(@Valid @RequestBody VebinarUpdateRequest request) {
         var response = vebinarService.updateVebinar(request);
         return ResponseEntity.ok(response);
     }
 
     @DeleteMapping("/{id}")
-    ResponseEntity<Void> deleteScheduleById(@NotNull @PathVariable UUID id) {
+    ResponseEntity<Void> deleteVebinarById(@NotNull @PathVariable UUID id) {
         vebinarService.deleteVebinar(id);
         return new ResponseEntity<>(HttpStatus.ACCEPTED);
     }

--- a/src/main/java/org/otus/platform/courseservice/dto/course/CourseDto.java
+++ b/src/main/java/org/otus/platform/courseservice/dto/course/CourseDto.java
@@ -12,6 +12,7 @@ public record CourseDto(
         String title,
         BigDecimal price,
         ZonedDateTime added,
-        ZonedDateTime startAt
+        ZonedDateTime startAt,
+        ZonedDateTime endAt
 ) {
 }

--- a/src/main/java/org/otus/platform/courseservice/dto/course/CreateCourseRequest.java
+++ b/src/main/java/org/otus/platform/courseservice/dto/course/CreateCourseRequest.java
@@ -11,6 +11,8 @@ public record CreateCourseRequest(
         @NotNull
         BigDecimal price,
         @NotNull
-        ZonedDateTime startAt
+        ZonedDateTime startAt,
+        @NotNull
+        ZonedDateTime endAt
 ) {
 }

--- a/src/main/java/org/otus/platform/courseservice/dto/course/UpdateCourseRequest.java
+++ b/src/main/java/org/otus/platform/courseservice/dto/course/UpdateCourseRequest.java
@@ -14,6 +14,8 @@ public record UpdateCourseRequest(
         @NotNull
         BigDecimal price,
         @NotNull
-        ZonedDateTime startAt
+        ZonedDateTime startAt,
+        @NotNull
+        ZonedDateTime endAt
 ) {
 }

--- a/src/main/java/org/otus/platform/courseservice/dto/homework/HomeworkCreateRequest.java
+++ b/src/main/java/org/otus/platform/courseservice/dto/homework/HomeworkCreateRequest.java
@@ -13,6 +13,8 @@ public record HomeworkCreateRequest(
         @NotNull
         UUID teacherId,
         @NotNull
+        UUID vebinarId,
+        @NotNull
         String content
 ) {
 }

--- a/src/main/java/org/otus/platform/courseservice/dto/homework/HomeworkDto.java
+++ b/src/main/java/org/otus/platform/courseservice/dto/homework/HomeworkDto.java
@@ -9,9 +9,10 @@ import java.util.UUID;
 @Builder
 public record HomeworkDto(
         UUID id,
-        UUID course,
-        UUID student,
-        UUID teacher,
+        UUID courseId,
+        UUID studentId,
+        UUID teacherId,
+        UUID vebinarId,
         CompleteStatus completeStatus,
         ZonedDateTime added,
         String content

--- a/src/main/java/org/otus/platform/courseservice/dto/homework/HomeworkUpdateRequest.java
+++ b/src/main/java/org/otus/platform/courseservice/dto/homework/HomeworkUpdateRequest.java
@@ -16,6 +16,8 @@ public record HomeworkUpdateRequest(
         @NotNull
         UUID teacherId,
         @NotNull
+        UUID vebinarId,
+        @NotNull
         String content
 ) {
 }

--- a/src/main/java/org/otus/platform/courseservice/dto/vebinar/MonthVebinarListDto.java
+++ b/src/main/java/org/otus/platform/courseservice/dto/vebinar/MonthVebinarListDto.java
@@ -1,0 +1,9 @@
+package org.otus.platform.courseservice.dto.vebinar;
+
+import java.util.List;
+
+public record MonthVebinarListDto(
+        Integer monthNumber,
+        List<VebinarDto> vebinars
+) {
+}

--- a/src/main/java/org/otus/platform/courseservice/dto/vebinar/VebinarListDto.java
+++ b/src/main/java/org/otus/platform/courseservice/dto/vebinar/VebinarListDto.java
@@ -3,6 +3,6 @@ package org.otus.platform.courseservice.dto.vebinar;
 import java.util.List;
 
 public record VebinarListDto(
-        List<VebinarDto> vebinar
+        List<MonthVebinarListDto> vebinar
 ) {
 }

--- a/src/main/java/org/otus/platform/courseservice/mapper/CourseMapper.java
+++ b/src/main/java/org/otus/platform/courseservice/mapper/CourseMapper.java
@@ -19,6 +19,7 @@ public class CourseMapper {
                 .price(course.getPrice())
                 .added(course.getAdded())
                 .startAt(course.getStartAt())
+                .endAt(course.getEndAt())
                 .build();
     }
 
@@ -27,6 +28,7 @@ public class CourseMapper {
                 .title(request.title())
                 .price(request.price())
                 .startAt(request.startAt())
+                .endAt(request.endAt())
                 .build();
     }
 

--- a/src/main/java/org/otus/platform/courseservice/mapper/HomeworkMapper.java
+++ b/src/main/java/org/otus/platform/courseservice/mapper/HomeworkMapper.java
@@ -6,6 +6,7 @@ import org.otus.platform.courseservice.model.homework.CompleteStatus;
 import org.otus.platform.courseservice.model.homework.Homework;
 import org.otus.platform.courseservice.model.course.Course;
 import org.otus.platform.courseservice.model.user.User;
+import org.otus.platform.courseservice.model.vebinar.Vebinar;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -14,19 +15,21 @@ public class HomeworkMapper {
     public HomeworkDto toHomeworkDto(Homework homework) {
         return HomeworkDto.builder()
                 .id(homework.getId())
-                .course(homework.getCourse().getId())
-                .student(homework.getStudent().getId())
-                .teacher(homework.getTeacher().getId())
+                .courseId(homework.getCourse().getId())
+                .studentId(homework.getStudent().getId())
+                .teacherId(homework.getTeacher().getId())
+                .vebinarId(homework.getVebinar().getId())
                 .content(homework.getContent())
                 .completeStatus(homework.getCompleteStatus())
                 .build();
     }
 
-    public Homework toHomework(HomeworkCreateRequest request, Course course, User student, User teacher) {
+    public Homework toHomework(HomeworkCreateRequest request, Course course, User student, User teacher, Vebinar vebinar) {
         return Homework.builder()
                 .course(course)
                 .student(student)
                 .teacher(teacher)
+                .vebinar(vebinar)
                 .content(request.content())
                 .completeStatus(CompleteStatus.InProgress)
                 .build();

--- a/src/main/java/org/otus/platform/courseservice/mapper/VebinarMapper.java
+++ b/src/main/java/org/otus/platform/courseservice/mapper/VebinarMapper.java
@@ -31,7 +31,7 @@ public class VebinarMapper {
     public Vebinar toVebinar(VebinarCreateRequest dto, Course course, User teacher) {
         return Vebinar.builder()
                 .course(course)
-                .title(course.getTitle())
+                .title(dto.title())
                 .lessonDate(dto.lessonDate())
                 .summary(dto.summary())
                 .teacher(teacher)

--- a/src/main/java/org/otus/platform/courseservice/model/course/Course.java
+++ b/src/main/java/org/otus/platform/courseservice/model/course/Course.java
@@ -35,6 +35,9 @@ public class Course {
     @Column(name = "start_at", nullable = false)
     private ZonedDateTime startAt;
 
+    @Column(name = "end_at", nullable = false)
+    private ZonedDateTime endAt;
+
     @Column(name = "deleted_at")
     private ZonedDateTime deletedAt;
 

--- a/src/main/java/org/otus/platform/courseservice/model/homework/Homework.java
+++ b/src/main/java/org/otus/platform/courseservice/model/homework/Homework.java
@@ -5,6 +5,7 @@ import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 import org.otus.platform.courseservice.model.course.Course;
 import org.otus.platform.courseservice.model.user.User;
+import org.otus.platform.courseservice.model.vebinar.Vebinar;
 
 import java.time.ZonedDateTime;
 import java.util.UUID;
@@ -29,6 +30,10 @@ public class Homework {
     @ManyToOne
     @JoinColumn(name = "student_id", nullable = false)
     private User student;
+
+    @ManyToOne
+    @JoinColumn(name = "vebinar_id", nullable = false)
+    private Vebinar vebinar;
 
     @ManyToOne
     @JoinColumn(name = "teacher_id", nullable = false)

--- a/src/main/java/org/otus/platform/courseservice/model/vebinar/Vebinar.java
+++ b/src/main/java/org/otus/platform/courseservice/model/vebinar/Vebinar.java
@@ -13,7 +13,7 @@ import java.util.UUID;
 @AllArgsConstructor
 @NoArgsConstructor
 @Entity
-@Table(name = "vebinar")
+@Table(name = "vebinars")
 public class Vebinar {
 
     @Id

--- a/src/main/java/org/otus/platform/courseservice/service/impl/CourseServiceImpl.java
+++ b/src/main/java/org/otus/platform/courseservice/service/impl/CourseServiceImpl.java
@@ -11,6 +11,7 @@ import org.otus.platform.courseservice.repository.CourseUserRepository;
 import org.otus.platform.courseservice.repository.UserRepository;
 import org.otus.platform.courseservice.service.CourseService;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.ZonedDateTime;
 import java.util.List;
@@ -26,6 +27,7 @@ public class CourseServiceImpl implements CourseService {
     private final CourseUserRepository courseUserRepository;
     private final UserRepository userRepository;
 
+    @Transactional
     @Override
     public CourseDto getCourseById(UUID id) {
         log.info("invoke getCourseById() method");
@@ -34,6 +36,7 @@ public class CourseServiceImpl implements CourseService {
         return courseMapper.toCourseDto(course);
     }
 
+    @Transactional
     @Override
     public CourseListDto getCoursesByUser(UUID id) {
         log.info("invoke getCoursesByUser() method");
@@ -43,6 +46,7 @@ public class CourseServiceImpl implements CourseService {
         return new CourseListDto(courseDtoList);
     }
 
+    @Transactional
     @Override
     public CourseUserListDto getUsersByCourse(UUID id) {
         log.info("invoke getUsersByCourse() method");
@@ -52,6 +56,7 @@ public class CourseServiceImpl implements CourseService {
         return new CourseUserListDto(userDtoList);
     }
 
+    @Transactional
     @Override
     public CourseDto createCourse(CreateCourseRequest request) {
         log.info("invoke createCourse() method");
@@ -60,6 +65,7 @@ public class CourseServiceImpl implements CourseService {
         return courseMapper.toCourseDto(savedCourse);
     }
 
+    @Transactional
     @Override
     public CourseDto updateCourse(UpdateCourseRequest request) {
         log.info("invoke updateCourse() method");
@@ -72,6 +78,7 @@ public class CourseServiceImpl implements CourseService {
         return courseMapper.toCourseDto(updatedCourse);
     }
 
+    @Transactional
     @Override
     public CourseDto joinToCourse(JoinToCourseRequest request) {
         log.info("invoke joinToCourse() method");
@@ -88,6 +95,7 @@ public class CourseServiceImpl implements CourseService {
         return courseMapper.toCourseDto(course);
     }
 
+    @Transactional
     @Override
     public void deleteCourse(UUID id) {
         log.info("invoke deleteCourse() method");

--- a/src/main/java/org/otus/platform/courseservice/service/impl/VebinarServiceImpl.java
+++ b/src/main/java/org/otus/platform/courseservice/service/impl/VebinarServiceImpl.java
@@ -3,19 +3,22 @@ package org.otus.platform.courseservice.service.impl;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.otus.platform.courseservice.dto.vebinar.VebinarCreateRequest;
-import org.otus.platform.courseservice.dto.vebinar.VebinarDto;
-import org.otus.platform.courseservice.dto.vebinar.VebinarListDto;
-import org.otus.platform.courseservice.dto.vebinar.VebinarUpdateRequest;
+import org.otus.platform.courseservice.dto.vebinar.*;
 import org.otus.platform.courseservice.mapper.VebinarMapper;
 import org.otus.platform.courseservice.repository.CourseRepository;
 import org.otus.platform.courseservice.repository.UserRepository;
 import org.otus.platform.courseservice.repository.VebinarRepository;
 import org.otus.platform.courseservice.service.VebinarService;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Month;
 import java.time.ZonedDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
 @Slf4j
@@ -27,25 +30,39 @@ public class VebinarServiceImpl implements VebinarService {
     private final VebinarMapper mapper;
     private final UserRepository userRepository;
 
+    @Transactional
     @Override
     public VebinarListDto getVebinarListByCourse(UUID id) {
-        log.info("invoke getCourseScheduleByCourse() method");
-        var vebinar = vebinarRepository.findAllByCourseId(id);
-        var vebinarListDto = mapper.toVebinarList(vebinar);
-        return new VebinarListDto(vebinarListDto);
+        log.info("invoke getVebinarListByCourse() method");
+        var vebinarList = vebinarRepository.findAllByCourseId(id);
+        var vebinarListDto = mapper.toVebinarList(vebinarList);
+        Map<Month, List<VebinarDto>> groupedByMonth = vebinarListDto.stream()
+                .collect(Collectors.groupingBy(vebinar -> vebinar.lessonDate().getMonth()));
+        Map<Integer, List<VebinarDto>> indexedMap = new HashMap<>();
+        int index = 1;
+        for (List<VebinarDto> value : groupedByMonth.values()) {
+            indexedMap.put(index++, value);
+        }
+
+        List<MonthVebinarListDto> monthVebinarListDtos = indexedMap.entrySet().stream()
+                .map(entry -> new MonthVebinarListDto(entry.getKey(), entry.getValue()))
+                .toList();
+        return new VebinarListDto(monthVebinarListDtos);
     }
 
+    @Transactional
     @Override
     public VebinarDto getVebinarById(UUID id) {
-        log.info("invoke getCourseScheduleById() method");
+        log.info("invoke getVebinarById() method");
         var vebinar = vebinarRepository.findByIdAndDeletedHashIsNull(id)
                 .orElseThrow(() -> new EntityNotFoundException("Schedule with id: " + id + " not found"));
         return mapper.toVebinarDto(vebinar);
     }
 
+    @Transactional
     @Override
     public VebinarDto createVebinar(VebinarCreateRequest request) {
-        log.info("invoke createCourseSchedule() method");
+        log.info("invoke createVebinar() method");
         var course = courseRepository.findByIdAndDeletedHashIsNull(request.courseId())
                 .orElseThrow(() -> new EntityNotFoundException("Course with id: " + request.courseId() + " not found"));
         var teacher = userRepository.findByIdAndDeletedHashIsNull(request.teacherId())
@@ -55,9 +72,10 @@ public class VebinarServiceImpl implements VebinarService {
         return mapper.toVebinarDto(savedVebinar);
     }
 
+    @Transactional
     @Override
     public VebinarDto updateVebinar(VebinarUpdateRequest request) {
-        log.info("invoke updateCourseSchedule() method");
+        log.info("invoke updateVebinar() method");
         var vebinar = vebinarRepository.findByIdAndDeletedHashIsNull(request.id())
                 .orElseThrow(() -> new EntityNotFoundException("Vebinar with id: " + request.id() + " not found"));
         if(vebinar.getCourse().getId() != request.courseId()) {
@@ -78,9 +96,10 @@ public class VebinarServiceImpl implements VebinarService {
         return mapper.toVebinarDto(savedSchedule);
     }
 
+    @Transactional
     @Override
     public void deleteVebinar(UUID id) {
-        log.info("invoke deleteScheduleById() method");
+        log.info("invoke deleteVebinar() method");
         var vebinar = vebinarRepository.findByIdAndDeletedHashIsNull(id)
                 .orElse(null);
         if(vebinar != null) {

--- a/src/main/resources/db/changelog/changesets/2024-03-13--002--create_vebinar_table.yaml
+++ b/src/main/resources/db/changelog/changesets/2024-03-13--002--create_vebinar_table.yaml
@@ -5,7 +5,7 @@ databaseChangeLog:
       author: Karen
       changes:
         - createTable:
-            tableName: vebinar
+            tableName: vebinars
             schemaName:  courseservice
             columns:
               - column:

--- a/src/main/resources/db/changelog/changesets/2024-03-17--001--add_column_end_at_to_courses.yaml
+++ b/src/main/resources/db/changelog/changesets/2024-03-17--001--add_column_end_at_to_courses.yaml
@@ -1,0 +1,14 @@
+databaseChangeLog:
+  - logicalFilePath: changesets/2024-03-17--001--add_column_end_at_to_courses.yaml
+  - changeSet:
+      id: add-end_at-to-course
+      author: Karen
+      changes:
+        - addColumn:
+            tableName: courses
+            columns:
+              - column:
+                  name: end_at
+                  type: timestamp with time zone
+                  constraints:
+                    nullable: false

--- a/src/main/resources/db/changelog/changesets/2024-03-17--002--add_vebinar_id_to_homework.yaml
+++ b/src/main/resources/db/changelog/changesets/2024-03-17--002--add_vebinar_id_to_homework.yaml
@@ -1,0 +1,16 @@
+databaseChangeLog:
+  - logicalFilePath: changesets/2024-03-17--002--add_vebinar_id_to_homework.yaml
+  - changeSet:
+      id: add_vebinar_id_to_homework
+      author: Karen
+      changes:
+        - addColumn:
+            tableName: homeworks
+            columns:
+              - column:
+                  name: vebinar_id
+                  type: uuid
+                  constraints:
+                    foreignKeyName: fk_vebinar_id_homeworks
+                    references: vebinars (id)
+                    nullable: false


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces changes related to adding `endAt` field, `vebinarId` association, and table renaming in various DTOs, models, and service implementations.

### Detailed summary
- Added `vebinarId` field to `HomeworkCreateRequest`, `HomeworkUpdateRequest`, and related DTOs
- Added `endAt` field to `CourseDto`, `CreateCourseRequest`, and `UpdateCourseRequest`
- Renamed `vebinar` to `MonthVebinarListDto` in `VebinarListDto`
- Updated table name to `vebinars` in `Vebinar` model
- Added `end_at` column to `Course` model
- Added `vebinar_id` column to `Homework` model
- Updated mappings and service methods accordingly

> The following files were skipped due to too many changes: `src/main/java/org/otus/platform/courseservice/service/impl/HomeworkServiceImpl.java`, `src/main/java/org/otus/platform/courseservice/service/impl/VebinarServiceImpl.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->